### PR TITLE
Add proprietary codecs and libinput

### DIFF
--- a/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-120.0.6099.315_rc-r1.ebuild
+++ b/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-120.0.6099.315_rc-r1.ebuild
@@ -34,13 +34,13 @@ IUSE="
 	asan
 	+build_tests
 	cdm_factory_daemon
-	+chrome_debug
+	chrome_debug
 	+cfi
 	cfm
 	chrome_debug_tests
 	chrome_dcheck
 	chrome_internal
-	chrome_media
+	+chrome_media
 	+chrome_remoting
 	clang_tidy
 	component_build
@@ -53,12 +53,12 @@ IUSE="
 	hw_details
 	feature_management
 	goma_thinlto
-	hevc_codec
+	+hevc_codec
 	+highdpi
 	intel_oemcrypto
 	internal_gles_conform
 	+libcxx
-	libinput
+	+libinput
 	mojo
 	msan
 	+nacl

--- a/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-120.0.6099.315_rc-r1.ebuild
+++ b/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-120.0.6099.315_rc-r1.ebuild
@@ -34,7 +34,7 @@ IUSE="
 	asan
 	+build_tests
 	cdm_factory_daemon
-	chrome_debug
+	-chrome_debug
 	+cfi
 	cfm
 	chrome_debug_tests
@@ -53,7 +53,7 @@ IUSE="
 	hw_details
 	feature_management
 	goma_thinlto
-	+hevc_codec
+	hevc_codec
 	+highdpi
 	intel_oemcrypto
 	internal_gles_conform

--- a/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-9999.ebuild
+++ b/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-9999.ebuild
@@ -34,13 +34,13 @@ IUSE="
 	asan
 	+build_tests
 	cdm_factory_daemon
-	+chrome_debug
+	chrome_debug
 	+cfi
 	cfm
 	chrome_debug_tests
 	chrome_dcheck
 	chrome_internal
-	chrome_media
+	+chrome_media
 	+chrome_remoting
 	clang_tidy
 	component_build
@@ -53,12 +53,12 @@ IUSE="
 	hw_details
 	feature_management
 	goma_thinlto
-	hevc_codec
+	+hevc_codec
 	+highdpi
 	intel_oemcrypto
 	internal_gles_conform
 	+libcxx
-	libinput
+	+libinput
 	mojo
 	msan
 	+nacl

--- a/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-9999.ebuild
+++ b/src/third_party/chromiumos-overlay/chromeos-base/chromeos-chrome/chromeos-chrome-9999.ebuild
@@ -34,7 +34,7 @@ IUSE="
 	asan
 	+build_tests
 	cdm_factory_daemon
-	chrome_debug
+	-chrome_debug
 	+cfi
 	cfm
 	chrome_debug_tests
@@ -53,7 +53,7 @@ IUSE="
 	hw_details
 	feature_management
 	goma_thinlto
-	+hevc_codec
+	hevc_codec
 	+highdpi
 	intel_oemcrypto
 	internal_gles_conform


### PR DESCRIPTION
@bak-seongbin @evelyn-widyasari-kho 
Hi, it is me again, I contributed to WayneOS a while ago, back when it was on GitLab.

An issue with WayneOS that still persists, that limits its use, is that it lacks proprietary codecs. There are many video sites that WayneOS won't play, because it doesn't have support for H.264, H.265, or AAC audio.

This makes it hard to use as a daily OS for the home user, because many common streaming and media sites don't work.

These changes are from ThoriumOS, my own ChromiumOS fork (which is also using the `reven` overlay as a base) > https://github.com/Alex313031/ThoriumOS

This change does 3 things:

1. Disables debug mode, for better performance (it sets `is_debug = false` and `is_official_build = true`)
2. Adds support for proprietary codecs including H.265 (i.e. HEVC)
3. Adds libinput support, which increases the number of input devices that will work out of the box by default. (Useful for tablets and weird keyboards)